### PR TITLE
feat: reenabled tailwind-rules and disabled its classname-order-rule

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -1,11 +1,13 @@
 import js from '@eslint/js'
 import pluginStylistic from '@stylistic/eslint-plugin'
+import tailwind from 'eslint-plugin-tailwindcss'
 import pluginTailwind from 'eslint-plugin-readable-tailwind'
 import pluginVue from 'eslint-plugin-vue'
 import pluginVueA11y from 'eslint-plugin-vuejs-accessibility'
 
 export default [
   js.configs.recommended,
+  ...tailwind.configs['flat/recommended'],
   ...pluginVue.configs['flat/recommended'],
   ...pluginVueA11y.configs['flat/recommended'],
   pluginStylistic.configs['recommended-flat'],
@@ -69,6 +71,10 @@ export default [
       'eqeqeq': ['error', 'smart'],
       'no-undef': 'off', // done by typescript
       '@typescript-eslint/no-explicit-any': 'warn',
+
+      // tailwind
+      // ********************
+      'tailwindcss/classnames-order': 'off',
 
       // vue
       // ********************

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -11,7 +11,8 @@
     "@stylistic/eslint-plugin": "^2.8.0",
     "eslint-plugin-readable-tailwind": "^1.8.0",
     "eslint-plugin-vue": "^9.28.0",
-    "eslint-plugin-vuejs-accessibility": "^2.4.1"
+    "eslint-plugin-vuejs-accessibility": "^2.4.1",
+    "eslint-plugin-tailwindcss": "^3.17.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Pull request

Added config that works in
https://github.com/teamnovu/kabelschacht-web/commit/c9c45ebaec518128f13e52687d272db9b1795eac

To my best knowledge it should work in the package as well, but I had no way to verify.

